### PR TITLE
Add an LTS 11 snapshop

### DIFF
--- a/snapshot-lts-11.yaml
+++ b/snapshot-lts-11.yaml
@@ -1,0 +1,10 @@
+resolver: lts-11.15
+name: snapshot-lts-11
+packages:
+- postgresql-connector-0.2.5
+- preamble-0.0.61
+- rtcm-0.2.17
+- sbp-2.3.16
+- serialport-0.4.7
+- shakers-0.0.48
+- warped-0.0.5


### PR DESCRIPTION
Creating an lts-11 snapshot so we can use the latest GHC and libraries.

I'm not sure how to make sure that this will work for all our projects, so
please let me know if I can test/build any projects to verify.